### PR TITLE
Update gitignore and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .venv
+
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
## Summary
- ignore Python caches and compiled bytecode

## Testing
- `python example.py` *(fails: ModuleNotFoundError: No module named 'bleak')*

------
https://chatgpt.com/codex/tasks/task_e_6868b329dfc0832abefcd0e91a7a9d2a